### PR TITLE
adds init submodules to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ $ colima start
 
 ### Dependencies and building the app
 
+First, initialize git submodules:
+
+```bash
+$ git submodule update --init --recursive
+```
+
+Then install dependencies and build:
+
 ```bash
 $ pnpm run bootstrap
 ```


### PR DESCRIPTION
Add missing git submodule initialization step to README setup instructions

🤖 Generated with [Claude Code](https://claude.ai/code)