### PR TITLE
Require team-authenticated sockets for QPS push events

### DIFF
--- a/app/src/client/cli/prompts/main.prompt.ts
+++ b/app/src/client/cli/prompts/main.prompt.ts
@@ -93,7 +93,7 @@ const mainLoop = async (
             break
           }
           case 'registerDevice': {
-            const ucan = await registerDevice(client)
+            const ucan = await registerDevice(client, community?.teamId)
             if (ucan != null) {
               lastUcan = ucan
             }

--- a/app/src/client/cli/prompts/push.prompt.ts
+++ b/app/src/client/cli/prompts/push.prompt.ts
@@ -21,6 +21,7 @@ const logger = createLogger('Client:Push')
  */
 export const registerDevice = async (
   client: WebsocketClient,
+  defaultTeamId?: string,
 ): Promise<string | undefined> => {
   const deviceToken = await input({
     message: 'Enter the FCM device token:',
@@ -55,12 +56,23 @@ export const registerDevice = async (
   })
   const platform = platformRaw as 'ios' | 'android'
 
+  const teamId = await input({
+    message: 'Enter the team ID:',
+    default: defaultTeamId,
+    validate: (value: string | undefined) => {
+      if (value == null || value === '') {
+        return 'Team ID is required'
+      }
+      return true
+    },
+  })
+
   const result = await promiseWithSpinner(
     async () => {
       const message: RegisterDeviceMessage = {
         ts: DateTime.utc().toMillis(),
         status: CommunityOperationStatus.SENDING,
-        payload: { deviceToken, bundleId, platform },
+        payload: { deviceToken, bundleId, platform, teamId },
       }
 
       const response = await client.sendMessage<RegisterDeviceResponse>(

--- a/app/src/nest/qps/push/push.service.spec.ts
+++ b/app/src/nest/qps/push/push.service.spec.ts
@@ -5,6 +5,7 @@ import { jest } from '@jest/globals'
 import { Test, type TestingModule } from '@nestjs/testing'
 import { PushService } from './push.service.js'
 import { PushErrorCode } from './push.types.js'
+import { QpsErrorReason } from '../qps.types.js'
 import { AWSSecretsService } from '../../utils/aws/aws-secrets.service.js'
 
 // Mock firebase-admin
@@ -103,6 +104,9 @@ describe('PushService', () => {
       const result = await pushService!.send('test-token', { title: 'Test' })
 
       expect(result.success).toBe(false)
+      expect(result.error).toBe(
+        QpsErrorReason.PushNotificationServiceNotAvailable,
+      )
       expect(result.errorCode).toBe(PushErrorCode.SERVICE_UNAVAILABLE)
     })
 

--- a/app/src/nest/qps/push/push.service.ts
+++ b/app/src/nest/qps/push/push.service.ts
@@ -15,6 +15,7 @@ import {
   PushErrorCode,
 } from './push.types.js'
 import { ConfigService } from '../../utils/config/config.service.js'
+import { QpsErrorReason } from '../qps.types.js'
 
 @Injectable()
 export class PushService implements OnModuleInit, OnModuleDestroy {
@@ -67,7 +68,7 @@ export class PushService implements OnModuleInit, OnModuleDestroy {
     if (!this.isAvailable(platform)) {
       return {
         success: false,
-        error: `Push service not available for platform: ${platform}`,
+        error: QpsErrorReason.PushNotificationServiceNotAvailable,
         errorCode: PushErrorCode.SERVICE_UNAVAILABLE,
       }
     }
@@ -196,7 +197,7 @@ export class PushService implements OnModuleInit, OnModuleDestroy {
     if (messaging == null) {
       return {
         success: false,
-        error: `FCM service not configured for platform: ${platform}`,
+        error: QpsErrorReason.PushNotificationServiceNotAvailable,
         errorCode: PushErrorCode.SERVICE_UNAVAILABLE,
       }
     }

--- a/app/src/nest/qps/qps.service.spec.ts
+++ b/app/src/nest/qps/qps.service.spec.ts
@@ -4,15 +4,22 @@ import type { UcanService } from './ucan/ucan.service.js'
 import type { PushService } from './push/push.service.js'
 
 describe('QPSService', () => {
+  const createUcan = jest.fn<UcanService['createUcan']>()
   const validateUcan = jest.fn<UcanService['validateUcan']>()
+  const isAvailable = jest.fn<PushService['isAvailable']>()
   const send = jest.fn<PushService['send']>()
   const sendMulticast = jest.fn<PushService['sendMulticast']>()
 
-  const ucanService: Pick<UcanService, 'validateUcan'> = {
+  const ucanService: Pick<UcanService, 'createUcan' | 'validateUcan'> = {
+    createUcan,
     validateUcan,
   }
 
-  const pushService: Pick<PushService, 'send' | 'sendMulticast'> = {
+  const pushService: Pick<
+    PushService,
+    'isAvailable' | 'send' | 'sendMulticast'
+  > = {
+    isAvailable,
     send,
     sendMulticast,
   }
@@ -21,10 +28,47 @@ describe('QPSService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    isAvailable.mockReturnValue(true)
     service = new QPSService(
       ucanService as unknown as UcanService,
       pushService as unknown as PushService,
     )
+  })
+
+  it('creates registration UCANs with platform and team ID', async () => {
+    createUcan.mockResolvedValue('test-ucan')
+
+    const result = await service.registerDevice(
+      'device-token',
+      'com.test.app',
+      'android',
+      'team-1',
+    )
+
+    expect(result).toEqual({ success: true, ucan: 'test-ucan' })
+    expect(isAvailable).toHaveBeenCalledWith('android')
+    expect(createUcan).toHaveBeenCalledWith(
+      'device-token',
+      'com.test.app',
+      'android',
+      'team-1',
+    )
+  })
+
+  it('returns UCAN metadata for authorization checks', async () => {
+    validateUcan.mockResolvedValue({
+      valid: true,
+      deviceToken: 'device-token',
+      platform: 'ios',
+      teamId: 'team-1',
+    })
+
+    await expect(service.validateUcan('test-ucan')).resolves.toEqual({
+      valid: true,
+      deviceToken: 'device-token',
+      platform: 'ios',
+      teamId: 'team-1',
+    })
   })
 
   it('sends data-only pushes to Android devices', async () => {

--- a/app/src/nest/qps/qps.service.ts
+++ b/app/src/nest/qps/qps.service.ts
@@ -12,6 +12,8 @@ import {
   type MulticastPushResult,
   type PushPayload,
 } from './push/push.types.js'
+import type { UcanValidationResult } from './ucan/ucan.types.js'
+import { QPS_MAX_BATCH_UCANS, QpsErrorReason } from './qps.types.js'
 
 /**
  * Result of a device registration
@@ -54,12 +56,14 @@ export class QPSService {
    *
    * @param deviceToken The FCM device token
    * @param bundleId The app bundle identifier
+   * @param teamId The team this UCAN authorizes push delivery for
    * @returns Registration result with UCAN token
    */
   async registerDevice(
     deviceToken: string,
     bundleId: string,
     platform: 'ios' | 'android',
+    teamId: string,
   ): Promise<RegistrationResult> {
     try {
       if (!this.pushService.isAvailable(platform)) {
@@ -68,7 +72,7 @@ export class QPSService {
         )
         return {
           success: false,
-          error: 'Push notification service not available',
+          error: QpsErrorReason.PushNotificationServiceNotAvailable,
         }
       }
 
@@ -76,6 +80,7 @@ export class QPSService {
         deviceToken,
         bundleId,
         platform,
+        teamId,
       )
 
       this.logger.log(`Device registered successfully`)
@@ -90,9 +95,16 @@ export class QPSService {
         error:
           error instanceof Error
             ? error.message
-            : 'Unknown error during registration',
+            : QpsErrorReason.UnknownRegistrationError,
       }
     }
+  }
+
+  /**
+   * Validate a UCAN and return its embedded metadata for authorization checks.
+   */
+  async validateUcan(ucanToken: string): Promise<UcanValidationResult> {
+    return await this.ucanService.validateUcan(ucanToken)
   }
 
   /**
@@ -119,7 +131,7 @@ export class QPSService {
       )
       return {
         success: false,
-        error: validation.error ?? 'Invalid UCAN token',
+        error: validation.error ?? QpsErrorReason.InvalidUcanToken,
       }
     }
 
@@ -159,13 +171,13 @@ export class QPSService {
   ): Promise<SendBatchPushResult> {
     if (ucans.length === 0) {
       return { success: true }
-    } else if (ucans.length > 500) {
+    } else if (ucans.length > QPS_MAX_BATCH_UCANS) {
       this.logger.debug(
-        `Batch push failed: ${ucans.length} UCANs exceeds firebase limit of 500`,
+        `Batch push failed: ${ucans.length} UCANs exceeds firebase limit of ${QPS_MAX_BATCH_UCANS}`,
       )
       return {
         success: false,
-        error: 'Batch size exceeds limit of 500',
+        error: QpsErrorReason.BatchSizeExceedsLimit,
       }
     }
 
@@ -190,7 +202,7 @@ export class QPSService {
     const totalValid = iosTokens.length + androidTokens.length
     if (totalValid === 0) {
       this.logger.warn(`Batch push failed: no valid UCANs`)
-      return { success: false, error: 'No valid device tokens' }
+      return { success: false, error: QpsErrorReason.NoValidDeviceTokens }
     }
 
     const iosPayload = this.makePayload('ios', title, body, data)
@@ -227,7 +239,7 @@ export class QPSService {
       )
       return {
         success: false,
-        error: 'All push notifications failed',
+        error: QpsErrorReason.AllPushNotificationsFailed,
         invalidTokens,
       }
     }

--- a/app/src/nest/qps/qps.types.ts
+++ b/app/src/nest/qps/qps.types.ts
@@ -1,0 +1,18 @@
+export const QPS_MAX_BATCH_UCANS = 500
+
+export enum QpsErrorReason {
+  PushNotificationServiceNotAvailable = 'Push notification service not available',
+  UnknownRegistrationError = 'Unknown error during registration',
+  RegistrationFailed = 'Registration failed',
+  InvalidUcanToken = 'Invalid UCAN token',
+  DeviceTokenNoLongerValid = 'Device token no longer valid',
+  PushNotificationFailed = 'Push notification failed',
+  BatchPushFailed = 'Batch push failed',
+  InvalidBatchPayload = 'Invalid batch push payload',
+  BatchSizeExceedsLimit = 'Batch size exceeds limit of 500',
+  NoValidDeviceTokens = 'No valid device tokens',
+  AllPushNotificationsFailed = 'All push notifications failed',
+  SocketNotSignedIntoTeam = 'Socket is not signed into this team',
+  SocketNotSignedIntoUcanTeam = 'Socket is not signed into the team associated with this UCAN',
+  SocketNotSignedIntoAnyUcanTeam = 'Socket is not signed into any team associated with these UCANs',
+}

--- a/app/src/nest/qps/ucan/ucan.service.spec.ts
+++ b/app/src/nest/qps/ucan/ucan.service.spec.ts
@@ -5,18 +5,37 @@ import { jest } from '@jest/globals'
 import { Test, type TestingModule } from '@nestjs/testing'
 import * as ucans from '@ucans/ucans'
 import { UcanService } from './ucan.service.js'
-import { EncryptionModule } from '../../encryption/enc.module.js'
-import { UtilsModule } from '../../utils/utils.module.js'
-import { AWSModule } from '../../utils/aws/aws.module.js'
+import { AWSSecretsService } from '../../utils/aws/aws-secrets.service.js'
 
 describe('UcanService', () => {
+  const TEST_TEAM_ID = 'test-team-id'
+
   let module: TestingModule | undefined = undefined
   let ucanService: UcanService | undefined = undefined
+  let secrets: Map<string, string | Uint8Array>
+  let awsSecretsService: jest.Mocked<Pick<AWSSecretsService, 'get' | 'create'>>
 
   beforeEach(async () => {
+    secrets = new Map()
+    awsSecretsService = {
+      get: jest.fn(
+        async secretName =>
+          await Promise.resolve(secrets.get(secretName) ?? null),
+      ),
+      create: jest.fn(async (secretName, secret) => {
+        secrets.set(secretName, secret)
+        await Promise.resolve()
+      }),
+    }
+
     module = await Test.createTestingModule({
-      imports: [UtilsModule, EncryptionModule, AWSModule],
-      providers: [UcanService],
+      providers: [
+        UcanService,
+        {
+          provide: AWSSecretsService,
+          useValue: awsSecretsService,
+        },
+      ],
     }).compile()
 
     await module.init()
@@ -45,7 +64,12 @@ describe('UcanService', () => {
       const deviceToken = 'test-fcm-device-token-123'
       const bundleId = 'com.tryquiet.quiet'
 
-      const ucan = await ucanService!.createUcan(deviceToken, bundleId, 'ios')
+      const ucan = await ucanService!.createUcan(
+        deviceToken,
+        bundleId,
+        'ios',
+        TEST_TEAM_ID,
+      )
 
       expect(ucan).toBeDefined()
       expect(typeof ucan).toBe('string')
@@ -56,12 +80,19 @@ describe('UcanService', () => {
       const deviceToken = 'roundtrip-test-token'
       const bundleId = 'com.tryquiet.quiet'
 
-      const ucan = await ucanService!.createUcan(deviceToken, bundleId, 'ios')
+      const ucan = await ucanService!.createUcan(
+        deviceToken,
+        bundleId,
+        'ios',
+        TEST_TEAM_ID,
+      )
       const validation = await ucanService!.validateUcan(ucan)
 
       expect(validation.valid).toBe(true)
       expect(validation.deviceToken).toBe(deviceToken)
       expect(validation.bundleId).toBe(bundleId)
+      expect(validation.platform).toBe('ios')
+      expect(validation.teamId).toBe(TEST_TEAM_ID)
     })
 
     it('should create self-issued UCANs (issuer === audience)', async () => {
@@ -69,6 +100,7 @@ describe('UcanService', () => {
         'test-token',
         'com.test.app',
         'ios',
+        TEST_TEAM_ID,
       )
       const parsed = ucans.parse(ucan)
 
@@ -82,12 +114,19 @@ describe('UcanService', () => {
       const deviceToken = 'validation-test-token'
       const bundleId = 'com.tryquiet.quiet'
 
-      const ucan = await ucanService!.createUcan(deviceToken, bundleId, 'ios')
+      const ucan = await ucanService!.createUcan(
+        deviceToken,
+        bundleId,
+        'ios',
+        TEST_TEAM_ID,
+      )
       const validation = await ucanService!.validateUcan(ucan)
 
       expect(validation.valid).toBe(true)
       expect(validation.deviceToken).toBe(deviceToken)
       expect(validation.bundleId).toBe(bundleId)
+      expect(validation.platform).toBe('ios')
+      expect(validation.teamId).toBe(TEST_TEAM_ID)
       expect(validation.error).toBeUndefined()
     })
 
@@ -113,6 +152,7 @@ describe('UcanService', () => {
         'test-token',
         'com.test.app',
         'ios',
+        TEST_TEAM_ID,
       )
 
       const parts = ucan.split('.')
@@ -130,6 +170,7 @@ describe('UcanService', () => {
         'original-token',
         'com.test.app',
         'ios',
+        TEST_TEAM_ID,
       )
 
       const parts = ucan.split('.')
@@ -172,7 +213,12 @@ describe('UcanService', () => {
       const deviceToken = 'test-token'
       const bundleId = 'com.test.app'
 
-      const ucan = await ucanService!.createUcan(deviceToken, bundleId, 'ios')
+      const ucan = await ucanService!.createUcan(
+        deviceToken,
+        bundleId,
+        'ios',
+        TEST_TEAM_ID,
+      )
       const parts = ucan.split('.')
       const payload = JSON.parse(
         Buffer.from(parts[1], 'base64url').toString('utf8'),
@@ -245,7 +291,12 @@ describe('UcanService', () => {
       const deviceToken = 'token-with_special.chars:123'
       const bundleId = 'com.tryquiet.quiet'
 
-      const ucan = await ucanService!.createUcan(deviceToken, bundleId, 'ios')
+      const ucan = await ucanService!.createUcan(
+        deviceToken,
+        bundleId,
+        'ios',
+        TEST_TEAM_ID,
+      )
       const validation = await ucanService!.validateUcan(ucan)
 
       expect(validation.valid).toBe(true)
@@ -256,7 +307,12 @@ describe('UcanService', () => {
       const deviceToken = 'a'.repeat(1000)
       const bundleId = 'com.tryquiet.quiet'
 
-      const ucan = await ucanService!.createUcan(deviceToken, bundleId, 'ios')
+      const ucan = await ucanService!.createUcan(
+        deviceToken,
+        bundleId,
+        'ios',
+        TEST_TEAM_ID,
+      )
       const validation = await ucanService!.validateUcan(ucan)
 
       expect(validation.valid).toBe(true)
@@ -276,6 +332,7 @@ describe('UcanService', () => {
           'test-token',
           bundleId,
           'ios',
+          TEST_TEAM_ID,
         )
         const validation = await ucanService!.validateUcan(ucan)
 
@@ -292,6 +349,7 @@ describe('UcanService', () => {
         'test-token',
         'com.test.app',
         'ios',
+        TEST_TEAM_ID,
       )
 
       const validation1 = await ucanService!.validateUcan(ucan)
@@ -306,11 +364,13 @@ describe('UcanService', () => {
         'token1',
         'com.test.app',
         'ios',
+        TEST_TEAM_ID,
       )
       const ucan2 = await ucanService!.createUcan(
         'token2',
         'com.test.app',
         'ios',
+        TEST_TEAM_ID,
       )
 
       expect(ucan1).not.toBe(ucan2)
@@ -329,6 +389,7 @@ describe('UcanService', () => {
         'valid-token',
         'com.test.app',
         'ios',
+        TEST_TEAM_ID,
       )
       const parts = ucan.split('.')
       const payload = JSON.parse(
@@ -351,6 +412,7 @@ describe('UcanService', () => {
         'valid-token',
         'com.test.app',
         'ios',
+        TEST_TEAM_ID,
       )
       const parts = ucan.split('.')
       const payload = JSON.parse(
@@ -372,6 +434,7 @@ describe('UcanService', () => {
         'valid-token',
         'com.test.app',
         'ios',
+        TEST_TEAM_ID,
       )
       const parts = ucan.split('.')
       const payload = JSON.parse(
@@ -393,6 +456,7 @@ describe('UcanService', () => {
         'valid-token',
         'com.test.app',
         'ios',
+        TEST_TEAM_ID,
       )
       const parts = ucan.split('.')
       const payload = JSON.parse(

--- a/app/src/nest/qps/ucan/ucan.service.spec.ts
+++ b/app/src/nest/qps/ucan/ucan.service.spec.ts
@@ -5,10 +5,7 @@ import { jest } from '@jest/globals'
 import { Test, type TestingModule } from '@nestjs/testing'
 import * as ucans from '@ucans/ucans'
 import { UcanService } from './ucan.service.js'
-import { EncryptionModule } from '../../encryption/enc.module.js'
-import { UtilsModule } from '../../utils/utils.module.js'
-import { AWSModule } from '../../utils/aws/aws.module.js'
-import type { AWSSecretsService } from '../../utils/aws/aws-secrets.service.js'
+import { AWSSecretsService } from '../../utils/aws/aws-secrets.service.js'
 
 describe('UcanService', () => {
   const TEST_TEAM_ID = 'test-team-id'
@@ -23,7 +20,7 @@ describe('UcanService', () => {
     awsSecretsService = {
       get: jest.fn(
         async secretName =>
-          await Promise.resolve(secrets.get(secretName) ?? null),
+          await Promise.resolve(secrets.get(secretName) ?? undefined),
       ),
       create: jest.fn(async (secretName, secret) => {
         secrets.set(secretName, secret)

--- a/app/src/nest/qps/ucan/ucan.service.ts
+++ b/app/src/nest/qps/ucan/ucan.service.ts
@@ -59,6 +59,7 @@ export class UcanService implements OnModuleInit {
     deviceToken: string,
     bundleId: string,
     platform: 'ios' | 'android',
+    teamId: string,
   ): Promise<string> {
     if (this.keypair == null || this.qpsDid == null) {
       throw new UcanError(
@@ -77,7 +78,7 @@ export class UcanService implements OnModuleInit {
           can: { namespace: 'push', segments: ['send'] },
         },
       ],
-      facts: [{ bundleId, platform }],
+      facts: [{ bundleId, platform, teamId }],
     })
 
     return ucans.encode(ucan)
@@ -158,15 +159,18 @@ export class UcanService implements OnModuleInit {
       const facts = parsed.payload.fct as Array<{
         bundleId?: string
         platform?: 'ios' | 'android'
+        teamId?: string
       }>
       const bundleId = facts?.[0]?.bundleId
       const platform = facts?.[0]?.platform
+      const teamId = facts?.[0]?.teamId
 
       return {
         valid: true,
         deviceToken,
         bundleId,
         platform,
+        teamId,
       }
     } catch (error) {
       this.logger.error(`Error validating UCAN`, error)

--- a/app/src/nest/qps/ucan/ucan.types.ts
+++ b/app/src/nest/qps/ucan/ucan.types.ts
@@ -27,6 +27,7 @@ export interface PushCapability {
 export interface UcanFacts {
   bundleId: string
   platform: 'ios' | 'android'
+  teamId: string
 }
 
 /**
@@ -37,6 +38,7 @@ export interface UcanValidationResult {
   deviceToken?: string
   bundleId?: string
   platform?: 'ios' | 'android'
+  teamId?: string
   error?: string
 }
 

--- a/app/src/nest/websocket/handlers/auth.handler.spec.ts
+++ b/app/src/nest/websocket/handlers/auth.handler.spec.ts
@@ -3,7 +3,7 @@ import { WebsocketEvents } from '../ws.types.js'
 import { CommunityOperationStatus } from './types/common.types.js'
 import type { AuthConnection } from '../../communities/auth/auth.connection.js'
 import type { CommunitiesManagerService } from '../../communities/communities-manager.service.js'
-import type { Community } from '../../communities/types.js'
+import type { ManagedCommunity } from '../../communities/types.js'
 import type { Server } from 'socket.io'
 import type { CommunitiesHandlerConfig } from './types/common.types.js'
 import type { QuietSocket } from '../ws.types.js'
@@ -88,10 +88,10 @@ describe('Communities auth WebSocket handlers', () => {
     return { authConnection, deliver, emit }
   }
 
-  function buildCommunity(authConnection: AuthConnection): Community {
+  function buildCommunity(authConnection: AuthConnection): ManagedCommunity {
     return {
       authConnections: new Map([[userId, authConnection]]),
-    } as unknown as Community
+    } as unknown as ManagedCommunity
   }
 
   async function callAuthSyncHandler(): Promise<void> {

--- a/app/src/nest/websocket/handlers/qps.handler.spec.ts
+++ b/app/src/nest/websocket/handlers/qps.handler.spec.ts
@@ -7,6 +7,7 @@ import type { QPSService } from '../../qps/qps.service.js'
 import { QPS_MAX_BATCH_UCANS, QpsErrorReason } from '../../qps/qps.types.js'
 import type { CommunitiesManagerService } from '../../communities/communities-manager.service.js'
 import { AuthStatus } from '../../communities/auth/types.js'
+import type { ManagedCommunity } from '../../communities/types.js'
 import type { Server } from 'socket.io'
 import type { QuietSocket } from '../ws.types.js'
 
@@ -15,17 +16,15 @@ interface AuthConnectionState {
   status: AuthStatus
 }
 
-interface ManagedCommunityAuthState {
-  authConnections: Map<string, AuthConnectionState>
-}
-
 describe('QPS WebSocket Handlers', () => {
   const teamId = 'test-team-id'
   const otherTeamId = 'other-team-id'
   const userId = 'test-user-id'
 
   let mockQpsService: jest.Mocked<QPSService>
-  let mockCommunitiesManager: { get: jest.Mock }
+  let mockCommunitiesManager: jest.Mocked<
+    Pick<CommunitiesManagerService, 'get'>
+  >
   let mockSocket: jest.Mocked<QuietSocket>
   let mockServer: jest.Mocked<Server>
   let handlers: Map<string, (...args: unknown[]) => unknown>
@@ -33,7 +32,7 @@ describe('QPS WebSocket Handlers', () => {
   function createManagedCommunity(
     status = AuthStatus.JOINED,
     socketId = 'test-socket-id',
-  ): ManagedCommunityAuthState {
+  ): ManagedCommunity {
     const authConnection: AuthConnectionState = {
       socketId,
       status,
@@ -41,7 +40,7 @@ describe('QPS WebSocket Handlers', () => {
 
     return {
       authConnections: new Map([[userId, authConnection]]),
-    }
+    } as unknown as ManagedCommunity
   }
 
   beforeEach(() => {
@@ -53,7 +52,9 @@ describe('QPS WebSocket Handlers', () => {
     } as unknown as jest.Mocked<QPSService>
 
     mockCommunitiesManager = {
-      get: jest.fn(async () => await Promise.resolve(createManagedCommunity())),
+      get: jest
+        .fn<CommunitiesManagerService['get']>()
+        .mockResolvedValue(createManagedCommunity()),
     }
 
     handlers = new Map()

--- a/app/src/nest/websocket/handlers/qps.handler.spec.ts
+++ b/app/src/nest/websocket/handlers/qps.handler.spec.ts
@@ -4,14 +4,43 @@ import { WebsocketEvents } from '../ws.types.js'
 import { CommunityOperationStatus } from './types/common.types.js'
 import type { QPSHandlerConfig } from './types/qps.types.js'
 import type { QPSService } from '../../qps/qps.service.js'
+import type { CommunitiesManagerService } from '../../communities/communities-manager.service.js'
+import { AuthStatus } from '../../communities/auth/types.js'
 import type { Server } from 'socket.io'
 import type { QuietSocket } from '../ws.types.js'
 
+interface AuthConnectionState {
+  socketId: string
+  status: AuthStatus
+}
+
+interface ManagedCommunityAuthState {
+  authConnections: Map<string, AuthConnectionState>
+}
+
 describe('QPS WebSocket Handlers', () => {
+  const teamId = 'test-team-id'
+  const userId = 'test-user-id'
+
   let mockQpsService: jest.Mocked<QPSService>
+  let mockCommunitiesManager: { get: jest.Mock }
   let mockSocket: jest.Mocked<QuietSocket>
   let mockServer: jest.Mocked<Server>
   let handlers: Map<string, (...args: unknown[]) => unknown>
+
+  function createManagedCommunity(
+    status = AuthStatus.JOINED,
+    socketId = 'test-socket-id',
+  ): ManagedCommunityAuthState {
+    const authConnection: AuthConnectionState = {
+      socketId,
+      status,
+    }
+
+    return {
+      authConnections: new Map([[userId, authConnection]]),
+    }
+  }
 
   beforeEach(() => {
     mockQpsService = {
@@ -20,10 +49,18 @@ describe('QPS WebSocket Handlers', () => {
       sendBatchPush: jest.fn(),
     } as unknown as jest.Mocked<QPSService>
 
+    mockCommunitiesManager = {
+      get: jest.fn(async () => await Promise.resolve(createManagedCommunity())),
+    }
+
     handlers = new Map()
 
     mockSocket = {
       id: 'test-socket-id',
+      data: {
+        teamId,
+        userId,
+      },
       on: jest.fn((event: string, handler: (...args: unknown[]) => unknown) => {
         handlers.set(event, handler)
         return mockSocket
@@ -36,6 +73,8 @@ describe('QPS WebSocket Handlers', () => {
       socketServer: mockServer,
       socket: mockSocket,
       qpsService: mockQpsService,
+      communitiesManager:
+        mockCommunitiesManager as unknown as CommunitiesManagerService,
     }
 
     registerQpsHandlers(config)
@@ -64,6 +103,34 @@ describe('QPS WebSocket Handlers', () => {
   })
 
   describe('handleRegisterDevice', () => {
+    it('should return ERROR and not register device when unauthenticated', async () => {
+      mockSocket.data = {}
+
+      const callback = jest.fn()
+      const handler = handlers.get(WebsocketEvents.QPSRegisterDevice)!
+      await handler(
+        {
+          ts: Date.now(),
+          status: '',
+          payload: {
+            deviceToken: 'fcm-token',
+            bundleId: 'com.test.app',
+            platform: 'android',
+          },
+        },
+        callback,
+      )
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock assertion
+      expect(mockQpsService.registerDevice).not.toHaveBeenCalled()
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: CommunityOperationStatus.ERROR,
+          reason: 'Authentication required',
+        }),
+      )
+    })
+
     it('should return SUCCESS with ucan on successful registration', async () => {
       mockQpsService.registerDevice.mockResolvedValue({
         success: true,
@@ -158,6 +225,30 @@ describe('QPS WebSocket Handlers', () => {
   })
 
   describe('handleSendPush', () => {
+    it('should return ERROR and not send push when unauthenticated', async () => {
+      mockSocket.data = {}
+
+      const callback = jest.fn()
+      const handler = handlers.get(WebsocketEvents.QPSSendPush)!
+      await handler(
+        {
+          ts: Date.now(),
+          status: '',
+          payload: { ucan: 'valid-ucan' },
+        },
+        callback,
+      )
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock assertion
+      expect(mockQpsService.sendPush).not.toHaveBeenCalled()
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: CommunityOperationStatus.ERROR,
+          reason: 'Authentication required',
+        }),
+      )
+    })
+
     it('should return SUCCESS on successful push', async () => {
       mockQpsService.sendPush.mockResolvedValue({ success: true })
 
@@ -267,6 +358,64 @@ describe('QPS WebSocket Handlers', () => {
   })
 
   describe('handleSendBatchPush', () => {
+    it('should return ERROR and not send batch push when auth has not joined', async () => {
+      mockCommunitiesManager.get.mockResolvedValue(
+        createManagedCommunity(AuthStatus.JOINING),
+      )
+
+      const callback = jest.fn()
+      const handler = handlers.get(WebsocketEvents.QPSSendBatchPush)!
+      await handler(
+        {
+          ts: Date.now(),
+          status: '',
+          payload: {
+            ucans: ['ucan-1'],
+          },
+        },
+        callback,
+      )
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock assertion
+      expect(mockQpsService.sendBatchPush).not.toHaveBeenCalled()
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: CommunityOperationStatus.ERROR,
+          reason: 'Authentication required',
+          payload: { invalidTokens: [] },
+        }),
+      )
+    })
+
+    it('should return ERROR and not call service when auth belongs to another socket', async () => {
+      mockCommunitiesManager.get.mockResolvedValue(
+        createManagedCommunity(AuthStatus.JOINED, 'other-socket-id'),
+      )
+
+      const callback = jest.fn()
+      const handler = handlers.get(WebsocketEvents.QPSSendBatchPush)!
+      await handler(
+        {
+          ts: Date.now(),
+          status: '',
+          payload: {
+            ucans: ['ucan-1'],
+          },
+        },
+        callback,
+      )
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock assertion
+      expect(mockQpsService.sendBatchPush).not.toHaveBeenCalled()
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: CommunityOperationStatus.ERROR,
+          reason: 'Authentication required',
+          payload: { invalidTokens: [] },
+        }),
+      )
+    })
+
     it('should return SUCCESS with invalidTokens on successful batch push', async () => {
       mockQpsService.sendBatchPush.mockResolvedValue({
         success: true,

--- a/app/src/nest/websocket/handlers/qps.handler.spec.ts
+++ b/app/src/nest/websocket/handlers/qps.handler.spec.ts
@@ -4,6 +4,7 @@ import { WebsocketEvents } from '../ws.types.js'
 import { CommunityOperationStatus } from './types/common.types.js'
 import type { QPSHandlerConfig } from './types/qps.types.js'
 import type { QPSService } from '../../qps/qps.service.js'
+import { QPS_MAX_BATCH_UCANS, QpsErrorReason } from '../../qps/qps.types.js'
 import type { CommunitiesManagerService } from '../../communities/communities-manager.service.js'
 import { AuthStatus } from '../../communities/auth/types.js'
 import type { Server } from 'socket.io'
@@ -20,6 +21,7 @@ interface ManagedCommunityAuthState {
 
 describe('QPS WebSocket Handlers', () => {
   const teamId = 'test-team-id'
+  const otherTeamId = 'other-team-id'
   const userId = 'test-user-id'
 
   let mockQpsService: jest.Mocked<QPSService>
@@ -47,6 +49,7 @@ describe('QPS WebSocket Handlers', () => {
       registerDevice: jest.fn(),
       sendPush: jest.fn(),
       sendBatchPush: jest.fn(),
+      validateUcan: jest.fn(),
     } as unknown as jest.Mocked<QPSService>
 
     mockCommunitiesManager = {
@@ -103,7 +106,7 @@ describe('QPS WebSocket Handlers', () => {
   })
 
   describe('handleRegisterDevice', () => {
-    it('should return ERROR and not register device when unauthenticated', async () => {
+    it('should return UNAUTHORIZED and not register device when socket is not signed into the requested team', async () => {
       mockSocket.data = {}
 
       const callback = jest.fn()
@@ -116,6 +119,7 @@ describe('QPS WebSocket Handlers', () => {
             deviceToken: 'fcm-token',
             bundleId: 'com.test.app',
             platform: 'android',
+            teamId,
           },
         },
         callback,
@@ -125,8 +129,8 @@ describe('QPS WebSocket Handlers', () => {
       expect(mockQpsService.registerDevice).not.toHaveBeenCalled()
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: CommunityOperationStatus.ERROR,
-          reason: 'Authentication required',
+          status: CommunityOperationStatus.UNAUTHORIZED,
+          reason: QpsErrorReason.SocketNotSignedIntoTeam,
         }),
       )
     })
@@ -147,6 +151,7 @@ describe('QPS WebSocket Handlers', () => {
             deviceToken: 'fcm-token',
             bundleId: 'com.test.app',
             platform: 'android',
+            teamId,
           },
         },
         callback,
@@ -157,6 +162,7 @@ describe('QPS WebSocket Handlers', () => {
         'fcm-token',
         'com.test.app',
         'android',
+        teamId,
       )
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -169,7 +175,7 @@ describe('QPS WebSocket Handlers', () => {
     it('should return ERROR when registration fails', async () => {
       mockQpsService.registerDevice.mockResolvedValue({
         success: false,
-        error: 'Push service not available',
+        error: QpsErrorReason.PushNotificationServiceNotAvailable,
       })
 
       const callback = jest.fn()
@@ -182,6 +188,7 @@ describe('QPS WebSocket Handlers', () => {
             deviceToken: 'fcm-token',
             bundleId: 'com.test.app',
             platform: 'android',
+            teamId,
           },
         },
         callback,
@@ -190,7 +197,7 @@ describe('QPS WebSocket Handlers', () => {
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
           status: CommunityOperationStatus.ERROR,
-          reason: 'Push service not available',
+          reason: QpsErrorReason.PushNotificationServiceNotAvailable,
         }),
       )
     })
@@ -210,6 +217,7 @@ describe('QPS WebSocket Handlers', () => {
             deviceToken: 'fcm-token',
             bundleId: 'com.test.app',
             platform: 'android',
+            teamId,
           },
         },
         callback,
@@ -218,14 +226,24 @@ describe('QPS WebSocket Handlers', () => {
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
           status: CommunityOperationStatus.ERROR,
-          reason: 'Registration failed',
+          reason: QpsErrorReason.RegistrationFailed,
         }),
       )
     })
   })
 
   describe('handleSendPush', () => {
-    it('should return ERROR and not send push when unauthenticated', async () => {
+    beforeEach(() => {
+      mockQpsService.validateUcan.mockResolvedValue({
+        valid: true,
+        deviceToken: 'device-token',
+        bundleId: 'com.test.app',
+        platform: 'ios',
+        teamId,
+      })
+    })
+
+    it('should return UNAUTHORIZED and not send push when socket is not signed into the UCAN team', async () => {
       mockSocket.data = {}
 
       const callback = jest.fn()
@@ -243,8 +261,8 @@ describe('QPS WebSocket Handlers', () => {
       expect(mockQpsService.sendPush).not.toHaveBeenCalled()
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: CommunityOperationStatus.ERROR,
-          reason: 'Authentication required',
+          status: CommunityOperationStatus.UNAUTHORIZED,
+          reason: QpsErrorReason.SocketNotSignedIntoUcanTeam,
         }),
       )
     })
@@ -282,10 +300,64 @@ describe('QPS WebSocket Handlers', () => {
       )
     })
 
-    it('should return ERROR for invalid UCAN', async () => {
+    it('should return ERROR for invalid UCAN metadata', async () => {
+      mockQpsService.validateUcan.mockResolvedValue({
+        valid: false,
+        error: QpsErrorReason.InvalidUcanToken,
+      })
+
+      const callback = jest.fn()
+      const handler = handlers.get(WebsocketEvents.QPSSendPush)!
+      await handler(
+        {
+          ts: Date.now(),
+          status: '',
+          payload: { ucan: 'invalid-ucan' },
+        },
+        callback,
+      )
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock assertion
+      expect(mockQpsService.sendPush).not.toHaveBeenCalled()
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: CommunityOperationStatus.ERROR,
+          reason: QpsErrorReason.InvalidUcanToken,
+        }),
+      )
+    })
+
+    it('should return UNAUTHORIZED when UCAN has no teamId', async () => {
+      mockQpsService.validateUcan.mockResolvedValue({
+        valid: true,
+        deviceToken: 'device-token',
+        platform: 'ios',
+      })
+
+      const callback = jest.fn()
+      const handler = handlers.get(WebsocketEvents.QPSSendPush)!
+      await handler(
+        {
+          ts: Date.now(),
+          status: '',
+          payload: { ucan: 'ucan-without-team' },
+        },
+        callback,
+      )
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock assertion
+      expect(mockQpsService.sendPush).not.toHaveBeenCalled()
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: CommunityOperationStatus.UNAUTHORIZED,
+        }),
+      )
+    })
+
+    it('should return ERROR for invalid UCAN during delivery', async () => {
       mockQpsService.sendPush.mockResolvedValue({
         success: false,
-        error: 'Invalid UCAN token',
+        error: QpsErrorReason.InvalidUcanToken,
         tokenInvalid: false,
       })
 
@@ -303,7 +375,7 @@ describe('QPS WebSocket Handlers', () => {
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
           status: CommunityOperationStatus.ERROR,
-          reason: 'Invalid UCAN token',
+          reason: QpsErrorReason.InvalidUcanToken,
         }),
       )
     })
@@ -311,7 +383,7 @@ describe('QPS WebSocket Handlers', () => {
     it('should return NOT_FOUND when device token is invalid', async () => {
       mockQpsService.sendPush.mockResolvedValue({
         success: false,
-        error: 'Device token no longer valid',
+        error: QpsErrorReason.DeviceTokenNoLongerValid,
         tokenInvalid: true,
       })
 
@@ -329,7 +401,7 @@ describe('QPS WebSocket Handlers', () => {
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
           status: CommunityOperationStatus.NOT_FOUND,
-          reason: 'Device token no longer valid',
+          reason: QpsErrorReason.DeviceTokenNoLongerValid,
         }),
       )
     })
@@ -351,14 +423,24 @@ describe('QPS WebSocket Handlers', () => {
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
           status: CommunityOperationStatus.ERROR,
-          reason: 'Push notification failed',
+          reason: QpsErrorReason.PushNotificationFailed,
         }),
       )
     })
   })
 
   describe('handleSendBatchPush', () => {
-    it('should return ERROR and not send batch push when auth has not joined', async () => {
+    beforeEach(() => {
+      mockQpsService.validateUcan.mockResolvedValue({
+        valid: true,
+        deviceToken: 'device-token',
+        bundleId: 'com.test.app',
+        platform: 'ios',
+        teamId,
+      })
+    })
+
+    it('should return UNAUTHORIZED and not send batch push when auth has not joined', async () => {
       mockCommunitiesManager.get.mockResolvedValue(
         createManagedCommunity(AuthStatus.JOINING),
       )
@@ -380,14 +462,14 @@ describe('QPS WebSocket Handlers', () => {
       expect(mockQpsService.sendBatchPush).not.toHaveBeenCalled()
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: CommunityOperationStatus.ERROR,
-          reason: 'Authentication required',
+          status: CommunityOperationStatus.UNAUTHORIZED,
+          reason: QpsErrorReason.SocketNotSignedIntoAnyUcanTeam,
           payload: { invalidTokens: [] },
         }),
       )
     })
 
-    it('should return ERROR and not call service when auth belongs to another socket', async () => {
+    it('should return UNAUTHORIZED and not call service when auth belongs to another socket', async () => {
       mockCommunitiesManager.get.mockResolvedValue(
         createManagedCommunity(AuthStatus.JOINED, 'other-socket-id'),
       )
@@ -409,8 +491,70 @@ describe('QPS WebSocket Handlers', () => {
       expect(mockQpsService.sendBatchPush).not.toHaveBeenCalled()
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: CommunityOperationStatus.ERROR,
-          reason: 'Authentication required',
+          status: CommunityOperationStatus.UNAUTHORIZED,
+          reason: QpsErrorReason.SocketNotSignedIntoAnyUcanTeam,
+          payload: { invalidTokens: [] },
+        }),
+      )
+    })
+
+    it('should filter out unauthorized UCANs before batch delivery', async () => {
+      mockQpsService.validateUcan
+        .mockResolvedValueOnce({
+          valid: true,
+          deviceToken: 'device-token-1',
+          platform: 'ios',
+          teamId,
+        })
+        .mockResolvedValueOnce({
+          valid: true,
+          deviceToken: 'device-token-2',
+          platform: 'ios',
+          teamId: otherTeamId,
+        })
+        .mockResolvedValueOnce({
+          valid: false,
+          error: QpsErrorReason.InvalidUcanToken,
+        })
+      mockCommunitiesManager.get.mockImplementation(async requestedTeamId => {
+        if (requestedTeamId === teamId) {
+          return await Promise.resolve(createManagedCommunity())
+        }
+        return await Promise.resolve(
+          createManagedCommunity(AuthStatus.JOINED, 'other-socket-id'),
+        )
+      })
+      mockQpsService.sendBatchPush.mockResolvedValue({
+        success: true,
+        invalidTokens: [],
+      })
+
+      const callback = jest.fn()
+      const handler = handlers.get(WebsocketEvents.QPSSendBatchPush)!
+      await handler(
+        {
+          ts: Date.now(),
+          status: '',
+          payload: {
+            ucans: ['ucan-1', 'ucan-2', 'ucan-3'],
+            title: 'Batch Test',
+            body: 'Hello All',
+            data: { key: 'value' },
+          },
+        },
+        callback,
+      )
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock assertion
+      expect(mockQpsService.sendBatchPush).toHaveBeenCalledWith(
+        ['ucan-1'],
+        'Batch Test',
+        'Hello All',
+        { key: 'value' },
+      )
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: CommunityOperationStatus.SUCCESS,
           payload: { invalidTokens: [] },
         }),
       )
@@ -483,7 +627,7 @@ describe('QPS WebSocket Handlers', () => {
     it('should return ERROR with invalidTokens on batch push failure', async () => {
       mockQpsService.sendBatchPush.mockResolvedValue({
         success: false,
-        error: 'All push notifications failed',
+        error: QpsErrorReason.AllPushNotificationsFailed,
         invalidTokens: ['token-1', 'token-2', 'token-3'],
       })
 
@@ -503,18 +647,13 @@ describe('QPS WebSocket Handlers', () => {
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
           status: CommunityOperationStatus.ERROR,
-          reason: 'All push notifications failed',
+          reason: QpsErrorReason.AllPushNotificationsFailed,
           payload: { invalidTokens: ['token-1', 'token-2', 'token-3'] },
         }),
       )
     })
 
-    it('should return ERROR with empty invalidTokens when error has no tokens', async () => {
-      mockQpsService.sendBatchPush.mockResolvedValue({
-        success: false,
-        error: 'Batch size exceeds limit of 500',
-      })
-
+    it('should reject oversized batches before validating UCANs', async () => {
       const callback = jest.fn()
       const handler = handlers.get(WebsocketEvents.QPSSendBatchPush)!
       await handler(
@@ -522,16 +661,47 @@ describe('QPS WebSocket Handlers', () => {
           ts: Date.now(),
           status: '',
           payload: {
-            ucans: Array(501).fill('ucan'),
+            ucans: Array(QPS_MAX_BATCH_UCANS + 1).fill('ucan'),
           },
         },
         callback,
       )
 
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock assertion
+      expect(mockQpsService.validateUcan).not.toHaveBeenCalled()
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock assertion
+      expect(mockQpsService.sendBatchPush).not.toHaveBeenCalled()
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
           status: CommunityOperationStatus.ERROR,
-          reason: 'Batch size exceeds limit of 500',
+          reason: QpsErrorReason.BatchSizeExceedsLimit,
+          payload: { invalidTokens: [] },
+        }),
+      )
+    })
+
+    it('should reject malformed batch UCAN payloads before validating UCANs', async () => {
+      const callback = jest.fn()
+      const handler = handlers.get(WebsocketEvents.QPSSendBatchPush)!
+      await handler(
+        {
+          ts: Date.now(),
+          status: '',
+          payload: {
+            ucans: 'ucan-1',
+          },
+        },
+        callback,
+      )
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock assertion
+      expect(mockQpsService.validateUcan).not.toHaveBeenCalled()
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock assertion
+      expect(mockQpsService.sendBatchPush).not.toHaveBeenCalled()
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: CommunityOperationStatus.ERROR,
+          reason: QpsErrorReason.InvalidBatchPayload,
           payload: { invalidTokens: [] },
         }),
       )
@@ -558,7 +728,7 @@ describe('QPS WebSocket Handlers', () => {
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
           status: CommunityOperationStatus.ERROR,
-          reason: 'Batch push failed',
+          reason: QpsErrorReason.BatchPushFailed,
           payload: { invalidTokens: [] },
         }),
       )

--- a/app/src/nest/websocket/handlers/qps.handler.ts
+++ b/app/src/nest/websocket/handlers/qps.handler.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 import { createLogger } from '../../app/logger/logger.js'
 import { CommunityOperationStatus } from './types/common.types.js'
 import { AuthStatus } from '../../communities/auth/types.js'
+import { QPS_MAX_BATCH_UCANS, QpsErrorReason } from '../../qps/qps.types.js'
 import type {
   QPSHandlerConfig,
   RegisterDeviceMessage,
@@ -14,17 +15,16 @@ import type {
 } from './types/qps.types.js'
 
 const baseLogger = createLogger('Websocket:Event:QPS')
-const UNAUTHORIZED_QPS_REASON = 'Authentication required'
 
 export function registerQpsHandlers(config: QPSHandlerConfig): void {
   const _logger = baseLogger.extend(config.socket.id)
   _logger.debug(`Initializing QPS WS event handlers`)
 
-  async function hasJoinedAuthConnection(): Promise<boolean> {
+  async function hasJoinedAuthConnection(teamId: string): Promise<boolean> {
     const { socket } = config
     const { data } = socket
-    const { teamId, userId } = data
-    if (teamId == null || userId == null) {
+    const { userId } = data
+    if (userId == null) {
       return false
     }
 
@@ -37,11 +37,11 @@ export function registerQpsHandlers(config: QPSHandlerConfig): void {
     )
   }
 
-  async function isAuthorizedForQps(): Promise<boolean> {
+  async function isAuthorizedForTeam(teamId: string): Promise<boolean> {
     try {
-      return await hasJoinedAuthConnection()
+      return await hasJoinedAuthConnection(teamId)
     } catch (error) {
-      _logger.warn('Error checking QPS auth state', error)
+      _logger.warn(`Error checking QPS auth state for team ${teamId}`, error)
       return false
     }
   }
@@ -51,27 +51,30 @@ export function registerQpsHandlers(config: QPSHandlerConfig): void {
     callback: (response: RegisterDeviceResponse) => void,
   ): Promise<void> {
     try {
-      if (!(await isAuthorizedForQps())) {
+      const { deviceToken, bundleId, platform, teamId } = message.payload
+
+      if (!(await isAuthorizedForTeam(teamId))) {
         const response: RegisterDeviceResponse = {
           ts: DateTime.utc().toMillis(),
-          status: CommunityOperationStatus.ERROR,
-          reason: UNAUTHORIZED_QPS_REASON,
+          status: CommunityOperationStatus.UNAUTHORIZED,
+          reason: QpsErrorReason.SocketNotSignedIntoTeam,
         }
         callback(response)
         return
       }
 
       const result = await config.qpsService.registerDevice(
-        message.payload.deviceToken,
-        message.payload.bundleId,
-        message.payload.platform,
+        deviceToken,
+        bundleId,
+        platform,
+        teamId,
       )
 
       if (!result.success || result.ucan == null) {
         const response: RegisterDeviceResponse = {
           ts: DateTime.utc().toMillis(),
           status: CommunityOperationStatus.ERROR,
-          reason: result.error ?? 'Registration failed',
+          reason: result.error ?? QpsErrorReason.RegistrationFailed,
         }
         callback(response)
         return
@@ -88,7 +91,7 @@ export function registerQpsHandlers(config: QPSHandlerConfig): void {
       const response: RegisterDeviceResponse = {
         ts: DateTime.utc().toMillis(),
         status: CommunityOperationStatus.ERROR,
-        reason: 'Registration failed',
+        reason: QpsErrorReason.RegistrationFailed,
       }
       callback(response)
     }
@@ -99,11 +102,25 @@ export function registerQpsHandlers(config: QPSHandlerConfig): void {
     callback: (response: SendPushResponse) => void,
   ): Promise<void> {
     try {
-      if (!(await isAuthorizedForQps())) {
+      const ucanInfo = await config.qpsService.validateUcan(
+        message.payload.ucan,
+      )
+      if (!ucanInfo.valid) {
         const response: SendPushResponse = {
           ts: DateTime.utc().toMillis(),
           status: CommunityOperationStatus.ERROR,
-          reason: UNAUTHORIZED_QPS_REASON,
+          reason: ucanInfo.error ?? QpsErrorReason.InvalidUcanToken,
+        }
+        callback(response)
+        return
+      }
+
+      const teamId = ucanInfo.teamId
+      if (teamId == null || !(await isAuthorizedForTeam(teamId))) {
+        const response: SendPushResponse = {
+          ts: DateTime.utc().toMillis(),
+          status: CommunityOperationStatus.UNAUTHORIZED,
+          reason: QpsErrorReason.SocketNotSignedIntoUcanTeam,
         }
         callback(response)
         return
@@ -121,7 +138,7 @@ export function registerQpsHandlers(config: QPSHandlerConfig): void {
           const response: SendPushResponse = {
             ts: DateTime.utc().toMillis(),
             status: CommunityOperationStatus.NOT_FOUND,
-            reason: result.error ?? 'Device token no longer valid',
+            reason: result.error ?? QpsErrorReason.DeviceTokenNoLongerValid,
           }
           callback(response)
           return
@@ -130,7 +147,7 @@ export function registerQpsHandlers(config: QPSHandlerConfig): void {
         const response: SendPushResponse = {
           ts: DateTime.utc().toMillis(),
           status: CommunityOperationStatus.ERROR,
-          reason: result.error ?? 'Push notification failed',
+          reason: result.error ?? QpsErrorReason.PushNotificationFailed,
         }
         callback(response)
         return
@@ -146,7 +163,7 @@ export function registerQpsHandlers(config: QPSHandlerConfig): void {
       const response: SendPushResponse = {
         ts: DateTime.utc().toMillis(),
         status: CommunityOperationStatus.ERROR,
-        reason: 'Push notification failed',
+        reason: QpsErrorReason.PushNotificationFailed,
       }
       callback(response)
     }
@@ -157,11 +174,47 @@ export function registerQpsHandlers(config: QPSHandlerConfig): void {
     callback: (response: SendBatchPushResponse) => void,
   ): Promise<void> {
     try {
-      if (!(await isAuthorizedForQps())) {
+      const { ucans } = message.payload
+      if (!Array.isArray(ucans)) {
         const response: SendBatchPushResponse = {
           ts: DateTime.utc().toMillis(),
           status: CommunityOperationStatus.ERROR,
-          reason: UNAUTHORIZED_QPS_REASON,
+          reason: QpsErrorReason.InvalidBatchPayload,
+          payload: { invalidTokens: [] },
+        }
+        callback(response)
+        return
+      }
+      if (ucans.length > QPS_MAX_BATCH_UCANS) {
+        const response: SendBatchPushResponse = {
+          ts: DateTime.utc().toMillis(),
+          status: CommunityOperationStatus.ERROR,
+          reason: QpsErrorReason.BatchSizeExceedsLimit,
+          payload: { invalidTokens: [] },
+        }
+        callback(response)
+        return
+      }
+
+      const authorizedUcans: string[] = []
+      for (const ucan of ucans) {
+        const ucanInfo = await config.qpsService.validateUcan(ucan)
+        const teamId = ucanInfo.teamId
+
+        if (
+          ucanInfo.valid &&
+          teamId != null &&
+          (await isAuthorizedForTeam(teamId))
+        ) {
+          authorizedUcans.push(ucan)
+        }
+      }
+
+      if (authorizedUcans.length === 0) {
+        const response: SendBatchPushResponse = {
+          ts: DateTime.utc().toMillis(),
+          status: CommunityOperationStatus.UNAUTHORIZED,
+          reason: QpsErrorReason.SocketNotSignedIntoAnyUcanTeam,
           payload: { invalidTokens: [] },
         }
         callback(response)
@@ -169,7 +222,7 @@ export function registerQpsHandlers(config: QPSHandlerConfig): void {
       }
 
       const result = await config.qpsService.sendBatchPush(
-        message.payload.ucans,
+        authorizedUcans,
         message.payload.title,
         message.payload.body,
         message.payload.data,
@@ -179,7 +232,7 @@ export function registerQpsHandlers(config: QPSHandlerConfig): void {
         const response: SendBatchPushResponse = {
           ts: DateTime.utc().toMillis(),
           status: CommunityOperationStatus.ERROR,
-          reason: result.error ?? 'Batch push failed',
+          reason: result.error ?? QpsErrorReason.BatchPushFailed,
           payload: { invalidTokens: result.invalidTokens ?? [] },
         }
         callback(response)
@@ -197,7 +250,7 @@ export function registerQpsHandlers(config: QPSHandlerConfig): void {
       const response: SendBatchPushResponse = {
         ts: DateTime.utc().toMillis(),
         status: CommunityOperationStatus.ERROR,
-        reason: 'Batch push failed',
+        reason: QpsErrorReason.BatchPushFailed,
         payload: { invalidTokens: [] },
       }
       callback(response)

--- a/app/src/nest/websocket/handlers/qps.handler.ts
+++ b/app/src/nest/websocket/handlers/qps.handler.ts
@@ -2,6 +2,7 @@ import { WebsocketEvents } from '../ws.types.js'
 import { DateTime } from 'luxon'
 import { createLogger } from '../../app/logger/logger.js'
 import { CommunityOperationStatus } from './types/common.types.js'
+import { AuthStatus } from '../../communities/auth/types.js'
 import type {
   QPSHandlerConfig,
   RegisterDeviceMessage,
@@ -13,16 +14,53 @@ import type {
 } from './types/qps.types.js'
 
 const baseLogger = createLogger('Websocket:Event:QPS')
+const UNAUTHORIZED_QPS_REASON = 'Authentication required'
 
 export function registerQpsHandlers(config: QPSHandlerConfig): void {
   const _logger = baseLogger.extend(config.socket.id)
   _logger.debug(`Initializing QPS WS event handlers`)
+
+  async function hasJoinedAuthConnection(): Promise<boolean> {
+    const { socket } = config
+    const { data } = socket
+    const { teamId, userId } = data
+    if (teamId == null || userId == null) {
+      return false
+    }
+
+    const community = await config.communitiesManager.get(teamId)
+    const authConnection = community?.authConnections?.get(userId)
+
+    return (
+      authConnection?.socketId === socket.id &&
+      authConnection.status === AuthStatus.JOINED
+    )
+  }
+
+  async function isAuthorizedForQps(): Promise<boolean> {
+    try {
+      return await hasJoinedAuthConnection()
+    } catch (error) {
+      _logger.warn('Error checking QPS auth state', error)
+      return false
+    }
+  }
 
   async function handleRegisterDevice(
     message: RegisterDeviceMessage,
     callback: (response: RegisterDeviceResponse) => void,
   ): Promise<void> {
     try {
+      if (!(await isAuthorizedForQps())) {
+        const response: RegisterDeviceResponse = {
+          ts: DateTime.utc().toMillis(),
+          status: CommunityOperationStatus.ERROR,
+          reason: UNAUTHORIZED_QPS_REASON,
+        }
+        callback(response)
+        return
+      }
+
       const result = await config.qpsService.registerDevice(
         message.payload.deviceToken,
         message.payload.bundleId,
@@ -61,6 +99,16 @@ export function registerQpsHandlers(config: QPSHandlerConfig): void {
     callback: (response: SendPushResponse) => void,
   ): Promise<void> {
     try {
+      if (!(await isAuthorizedForQps())) {
+        const response: SendPushResponse = {
+          ts: DateTime.utc().toMillis(),
+          status: CommunityOperationStatus.ERROR,
+          reason: UNAUTHORIZED_QPS_REASON,
+        }
+        callback(response)
+        return
+      }
+
       const result = await config.qpsService.sendPush(
         message.payload.ucan,
         message.payload.title,
@@ -109,6 +157,17 @@ export function registerQpsHandlers(config: QPSHandlerConfig): void {
     callback: (response: SendBatchPushResponse) => void,
   ): Promise<void> {
     try {
+      if (!(await isAuthorizedForQps())) {
+        const response: SendBatchPushResponse = {
+          ts: DateTime.utc().toMillis(),
+          status: CommunityOperationStatus.ERROR,
+          reason: UNAUTHORIZED_QPS_REASON,
+          payload: { invalidTokens: [] },
+        }
+        callback(response)
+        return
+      }
+
       const result = await config.qpsService.sendBatchPush(
         message.payload.ucans,
         message.payload.title,

--- a/app/src/nest/websocket/handlers/types/qps.types.ts
+++ b/app/src/nest/websocket/handlers/types/qps.types.ts
@@ -1,9 +1,11 @@
 import type { BaseHandlerConfig, BaseWebsocketMessage } from '../../ws.types.js'
 import type { QPSService } from '../../../qps/qps.service.js'
 import type { CommunityOperationStatus } from './common.types.js'
+import type { CommunitiesManagerService } from '../../../communities/communities-manager.service.js'
 
 export interface QPSHandlerConfig extends BaseHandlerConfig {
   qpsService: QPSService
+  communitiesManager: CommunitiesManagerService
 }
 
 export interface RegisterDevicePayload {

--- a/app/src/nest/websocket/handlers/types/qps.types.ts
+++ b/app/src/nest/websocket/handlers/types/qps.types.ts
@@ -12,6 +12,7 @@ export interface RegisterDevicePayload {
   deviceToken: string
   bundleId: string
   platform: 'ios' | 'android'
+  teamId: string
 }
 
 export interface RegisterDeviceMessage

--- a/app/src/nest/websocket/ws.gateway.ts
+++ b/app/src/nest/websocket/ws.gateway.ts
@@ -203,6 +203,7 @@ export class WebsocketGateway
       const qpsConfig: QPSHandlerConfig = {
         ...baseConfig,
         qpsService: this.qpsService,
+        communitiesManager: this.communitiesManager,
       }
       registerQpsHandlers(qpsConfig)
     }

--- a/tools/push-notification-test/README.md
+++ b/tools/push-notification-test/README.md
@@ -69,6 +69,9 @@ Make sure QPS has Firebase credentials configured:
 export FIREBASE_IOS_PROJECT_ID="your-project"
 export FIREBASE_IOS_CLIENT_EMAIL="firebase-adminsdk-xxx@your-project.iam.gserviceaccount.com"
 export FIREBASE_IOS_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+export FIREBASE_ANDROID_PROJECT_ID="your-android-project"
+export FIREBASE_ANDROID_CLIENT_EMAIL="firebase-adminsdk-xxx@your-android-project.iam.gserviceaccount.com"
+export FIREBASE_ANDROID_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
 ```
 
 ## Usage
@@ -81,7 +84,8 @@ export FIREBASE_IOS_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIV
    - An FCM device token will be generated
 
 3. **Register with QPS**: Click "Register Device"
-   - Sends a `register-device-token` WebSocket event with your FCM token
+   - Enter the bundle ID, platform, and signed-in team ID
+   - Sends a `register-device-token` WebSocket event with your FCM token and team ID
    - You'll receive a UCAN token for authorization
 
 4. **Send Test Push**: Enter a title/body and click "Send Push Notification"
@@ -97,7 +101,7 @@ QPS uses Socket.io WebSocket events for all operations (not HTTP):
 | `register-device-token` | client → server | Register FCM device token, returns UCAN |
 | `qps-send-push` | client → server | Send push notification using UCAN |
 
-Both events use acknowledgment callbacks. The response `status` field will be `success`, `error`, or `not found` (device token expired).
+Both events use acknowledgment callbacks. The response `status` field will be `success`, `error`, `unauthorized`, or `not found` (device token expired).
 
 ## Troubleshooting
 
@@ -119,6 +123,11 @@ Both events use acknowledgment callbacks. The response `status` field will be `s
 ### "Registration failed: Push service not available"
 - QPS server needs Firebase credentials configured
 - Check that `FIREBASE_IOS_PROJECT_ID`, `FIREBASE_IOS_CLIENT_EMAIL`, and `FIREBASE_IOS_PRIVATE_KEY` are set
+- For Android registrations, also check `FIREBASE_ANDROID_PROJECT_ID`, `FIREBASE_ANDROID_CLIENT_EMAIL`, and `FIREBASE_ANDROID_PRIVATE_KEY`
+
+### "Socket is not signed into this team"
+- Register after the WebSocket client has signed into the team ID used for the UCAN
+- Check that the team ID matches the active community
 
 ### "Device token no longer valid — re-register"
 - The FCM token has expired or been revoked; click "Register Device" again after getting a fresh token

--- a/tools/push-notification-test/index.html
+++ b/tools/push-notification-test/index.html
@@ -25,7 +25,7 @@
     }
     .card h2 { margin-top: 0; font-size: 14px; color: #888; text-transform: uppercase; }
     label { display: block; margin-bottom: 8px; font-size: 14px; color: #aaa; }
-    input, textarea {
+    input, select, textarea {
       width: 100%;
       padding: 10px;
       border: 1px solid #333;
@@ -141,6 +141,13 @@
     <h2>3. Register with QPS</h2>
     <label>Bundle ID</label>
     <input type="text" id="bundle-id" value="com.tryquiet.quiet">
+    <label>Platform</label>
+    <select id="platform">
+      <option value="ios">iOS</option>
+      <option value="android">Android</option>
+    </select>
+    <label>Team ID</label>
+    <input type="text" id="team-id" placeholder="Enter signed-in team ID">
     <button onclick="registerDevice()">Register Device</button>
     <div id="ucan-display" class="hidden">
       <label>UCAN Token:</label>
@@ -358,13 +365,18 @@
         }
 
         const bundleId = document.getElementById('bundle-id').value;
+        const platform = document.getElementById('platform').value;
+        const teamId = document.getElementById('team-id').value;
+        if (!teamId) {
+          throw new Error('Team ID is required');
+        }
 
         log(`Registering device with QPS...`);
 
         const message = {
           ts: Date.now(),
           status: 'sending',
-          payload: { deviceToken: fcmToken, bundleId },
+          payload: { deviceToken: fcmToken, bundleId, platform, teamId },
         };
 
         const response = await socket.emitWithAck('register-device-token', message);


### PR DESCRIPTION
## Summary

- Require `register-device-token` payloads to include `teamId`, and only mint a QPS UCAN when the socket has a JOINED auth connection for that team.
- Store `teamId` in QPS UCAN facts so `qps-send-push` and `qps-send-batch-push` can enforce team authorization before delivery.
- Plumb `teamId` through the QPS CLI and push notification test tool.
- Expand QPS handler/service/UCAN tests for unauthorized sockets, missing UCAN team IDs, batch filtering, and batch limit handling.

## Implementation notes

- Team auth check is centralized in the QPS websocket handler: `app/src/nest/websocket/handlers/qps.handler.ts:23`.
- Registration rejects sockets not signed into the requested team before creating a UCAN: `app/src/nest/websocket/handlers/qps.handler.ts:54`.
- Single-send authorization is based on the UCAN’s embedded team ID: `app/src/nest/websocket/handlers/qps.handler.ts:118`.
- Batch sends filter unauthorized UCANs before delivery: `app/src/nest/websocket/handlers/qps.handler.ts:199`.
- UCAN creation/validation now carries `teamId` in facts: `app/src/nest/qps/ucan/ucan.service.ts:71`, `app/src/nest/qps/ucan/ucan.types.ts:27`.
- The register payload type now requires `teamId`: `app/src/nest/websocket/handlers/types/qps.types.ts:11`.