### PR TITLE
Remove Env Var Secret fallbacks

### DIFF
--- a/app/src/nest/encryption/server-key-manager.service.spec.ts
+++ b/app/src/nest/encryption/server-key-manager.service.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for ServerKeyManagerService
+ *
+ * Regression coverage for issue #3290: a transient secrets-backend failure must
+ * not be misread as "no server encryption key exists", which would regenerate
+ * the key and make every previously stored keyring undecryptable. These tests
+ * drive _initOrRetrieveServerEncKey (via encrypt) with a mocked
+ * AWSSecretsService so they stay independent of Redis/AWS.
+ */
+import { jest } from '@jest/globals'
+import { ServerKeyManagerService } from './server-key-manager.service.js'
+import { SodiumHelper } from './sodium.helper.js'
+import type { AWSSecretsService } from '../utils/aws/aws-secrets.service.js'
+
+describe('ServerKeyManagerService - server encryption key retrieval failure handling', () => {
+  let sodiumHelper: SodiumHelper
+
+  const createMockSecrets = (): {
+    get: jest.Mock<(name: string) => Promise<string | Uint8Array | undefined>>
+    create: jest.Mock<(name: string, secret: string) => Promise<void>>
+  } => ({
+    get: jest.fn<(name: string) => Promise<string | Uint8Array | undefined>>(),
+    create: jest.fn<(name: string, secret: string) => Promise<void>>(),
+  })
+
+  const makeService = (
+    mock: ReturnType<typeof createMockSecrets>,
+  ): ServerKeyManagerService =>
+    new ServerKeyManagerService(
+      mock as unknown as AWSSecretsService,
+      sodiumHelper,
+    )
+
+  beforeAll(async () => {
+    sodiumHelper = new SodiumHelper()
+    await sodiumHelper.onModuleInit()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('does not generate a new server encryption key when retrieval fails transiently', async () => {
+    const mockSecrets = createMockSecrets()
+    mockSecrets.get.mockRejectedValueOnce(new Error('AWS unavailable'))
+
+    const service = makeService(mockSecrets)
+
+    await expect(service.encrypt('payload')).rejects.toThrow('AWS unavailable')
+    expect(mockSecrets.create).not.toHaveBeenCalled()
+  })
+
+  it('generates and stores a new server encryption key only when none exists', async () => {
+    const mockSecrets = createMockSecrets()
+    mockSecrets.get.mockResolvedValueOnce(undefined)
+    mockSecrets.create.mockResolvedValueOnce(undefined)
+
+    const service = makeService(mockSecrets)
+    await service.encrypt('payload')
+
+    expect(mockSecrets.create).toHaveBeenCalledTimes(1)
+  })
+
+  it('loads the existing server encryption key without regenerating it', async () => {
+    const existingKey = sodiumHelper.toBase64(
+      sodiumHelper.sodium.crypto_secretbox_keygen(),
+    )
+    const mockSecrets = createMockSecrets()
+    mockSecrets.get.mockResolvedValueOnce(existingKey)
+
+    const service = makeService(mockSecrets)
+    const encrypted = await service.encrypt('payload')
+
+    expect(mockSecrets.create).not.toHaveBeenCalled()
+    expect(encrypted.payload).toBeDefined()
+    expect(encrypted.nonce).toBeDefined()
+  })
+})

--- a/app/src/nest/nse/nse-jwt-options.service.ts
+++ b/app/src/nest/nse/nse-jwt-options.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common'
 import { JwtModuleOptions, JwtOptionsFactory } from '@nestjs/jwt'
-import { randomBytes } from 'node:crypto'
 import { createLogger } from '../app/logger/logger.js'
 import { AWSSecretsService } from '../utils/aws/aws-secrets.service.js'
 import { EnvVars } from '../utils/config/env_vars.js'
@@ -9,29 +8,24 @@ const logger = createLogger('NseAuth:JwtOptions')
 
 @Injectable()
 export class NseJwtOptionsService implements JwtOptionsFactory {
-  private fallbackSecret: string | undefined
-
   constructor(private readonly awsSecretsService: AWSSecretsService) {}
 
   public async createJwtOptions(): Promise<JwtModuleOptions> {
-    const secret =
-      (await this.awsSecretsService.getSecretEnvVar(EnvVars.NSE_JWT_SECRET)) ??
-      this.getFallbackSecret()
+    // No fallback: the JWT signing secret must come from the secrets manager. A
+    // generated fallback would silently rotate the signing key (invalidating all
+    // previously issued tokens) and mask a misconfigured or unreachable backend,
+    // so a missing or unavailable secret fails loudly instead.
+    const secret = await this.awsSecretsService.getSecretEnvVar(
+      EnvVars.NSE_JWT_SECRET,
+    )
+    if (secret == null) {
+      logger.error('NSE_JWT_SECRET is not configured')
+      throw new Error('NSE_JWT_SECRET is not configured')
+    }
 
     return {
       secret,
       signOptions: { expiresIn: 900 },
     }
-  }
-
-  private getFallbackSecret(): string {
-    if (this.fallbackSecret == null) {
-      logger.warn(
-        'NSE_JWT_SECRET not set — tokens will be invalid after process restart',
-      )
-      this.fallbackSecret = randomBytes(32).toString('base64url')
-    }
-
-    return this.fallbackSecret
   }
 }

--- a/app/src/nest/qps/push/push.service.ts
+++ b/app/src/nest/qps/push/push.service.ts
@@ -262,9 +262,19 @@ export class PushService implements OnModuleInit, OnModuleDestroy {
     const clientEmail = ConfigService.getString(
       EnvVars.FIREBASE_IOS_CLIENT_EMAIL,
     )
-    const privateKey = await this.awsSecretsService.getSecretEnvVar(
-      EnvVars.FIREBASE_IOS_PRIVATE_KEY,
-    )
+    let privateKey: string | undefined
+    try {
+      privateKey = await this.awsSecretsService.getSecretEnvVar(
+        EnvVars.FIREBASE_IOS_PRIVATE_KEY,
+      )
+    } catch (error) {
+      this.logger.error(
+        `Failed to retrieve iOS FCM private key from secrets manager. iOS push notifications will be unavailable.`,
+        error,
+      )
+      this.iosAvailable = false
+      return
+    }
 
     if (projectId == null || clientEmail == null || privateKey == null) {
       this.logger.error(
@@ -311,9 +321,19 @@ export class PushService implements OnModuleInit, OnModuleDestroy {
     const clientEmail = ConfigService.getString(
       EnvVars.FIREBASE_ANDROID_CLIENT_EMAIL,
     )
-    const privateKey = await this.awsSecretsService.getSecretEnvVar(
-      EnvVars.FIREBASE_ANDROID_PRIVATE_KEY,
-    )
+    let privateKey: string | undefined
+    try {
+      privateKey = await this.awsSecretsService.getSecretEnvVar(
+        EnvVars.FIREBASE_ANDROID_PRIVATE_KEY,
+      )
+    } catch (error) {
+      this.logger.error(
+        `Failed to retrieve Android FCM private key from secrets manager. Android push notifications will be unavailable.`,
+        error,
+      )
+      this.androidAvailable = false
+      return
+    }
 
     if (projectId == null || clientEmail == null || privateKey == null) {
       this.logger.warn(

--- a/app/src/nest/qps/ucan/ucan.service.spec.ts
+++ b/app/src/nest/qps/ucan/ucan.service.spec.ts
@@ -8,6 +8,7 @@ import { UcanService } from './ucan.service.js'
 import { EncryptionModule } from '../../encryption/enc.module.js'
 import { UtilsModule } from '../../utils/utils.module.js'
 import { AWSModule } from '../../utils/aws/aws.module.js'
+import type { AWSSecretsService } from '../../utils/aws/aws-secrets.service.js'
 
 describe('UcanService', () => {
   let module: TestingModule | undefined = undefined
@@ -408,5 +409,62 @@ describe('UcanService', () => {
       expect(validation.valid).toBe(false)
       expect(validation.error).toBeDefined()
     })
+  })
+})
+
+/**
+ * Regression coverage for issue #3290: a transient secrets-backend failure must
+ * not be misread as "no signing key exists", which would regenerate the QPS
+ * signing key and invalidate every previously issued UCAN. These tests drive
+ * initializeKeypair with a mocked AWSSecretsService so they stay independent of
+ * Redis/AWS.
+ */
+describe('UcanService - signing key retrieval failure handling', () => {
+  const createMockSecrets = (): {
+    get: jest.Mock<(name: string) => Promise<string | Uint8Array | undefined>>
+    create: jest.Mock<(name: string, secret: string) => Promise<void>>
+  } => ({
+    get: jest.fn<(name: string) => Promise<string | Uint8Array | undefined>>(),
+    create: jest.fn<(name: string, secret: string) => Promise<void>>(),
+  })
+
+  const makeService = (
+    mock: ReturnType<typeof createMockSecrets>,
+  ): UcanService => new UcanService(mock as unknown as AWSSecretsService)
+
+  it('does not generate a new signing key when retrieval fails transiently', async () => {
+    const mockSecrets = createMockSecrets()
+    mockSecrets.get.mockRejectedValueOnce(new Error('AWS unavailable'))
+
+    const service = makeService(mockSecrets)
+
+    await expect(service.onModuleInit()).rejects.toThrow('AWS unavailable')
+    expect(mockSecrets.create).not.toHaveBeenCalled()
+  })
+
+  it('generates and stores a new signing key only when none exists', async () => {
+    const mockSecrets = createMockSecrets()
+    mockSecrets.get.mockResolvedValueOnce(undefined)
+    mockSecrets.create.mockResolvedValueOnce(undefined)
+
+    const service = makeService(mockSecrets)
+    await service.onModuleInit()
+
+    expect(mockSecrets.create).toHaveBeenCalledTimes(1)
+    expect(service.getDid()).toMatch(/^did:key:z[a-zA-Z0-9]+$/)
+  })
+
+  it('loads the existing signing key without regenerating it', async () => {
+    const existingKeypair = await ucans.EdKeypair.create({ exportable: true })
+    const existingSecret = await existingKeypair.export('base64')
+
+    const mockSecrets = createMockSecrets()
+    mockSecrets.get.mockResolvedValueOnce(existingSecret)
+
+    const service = makeService(mockSecrets)
+    await service.onModuleInit()
+
+    expect(mockSecrets.create).not.toHaveBeenCalled()
+    expect(service.getDid()).toBe(existingKeypair.did())
   })
 })

--- a/app/src/nest/storage/postgres/const.ts
+++ b/app/src/nest/storage/postgres/const.ts
@@ -1,10 +1,3 @@
-export const DEFAULT_POSTGRES_DB_NAME = 'qss'
-export const DEFAULT_POSTGRES_DEBUG = false
-export const DEFAULT_POSTGRES_PORT = 5432
-export const DEFAULT_POSTGRES_HOST = 'localhost'
-export const DEFAULT_POSTGRES_USERNAME = 'postgres'
-export const DEFAULT_POSTGRES_PASSWORD = 'postgres'
-
 export enum TableNames {
   COMMUNITIES = 'communities',
   LOG_ENTRY_SYNC = 'log_entry_sync',

--- a/app/src/nest/utils/aws/aws-secrets.service.spec.ts
+++ b/app/src/nest/utils/aws/aws-secrets.service.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for AWSSecretsService
+ */
+import { jest } from '@jest/globals'
+import type {
+  CreateSecretCommand,
+  CreateSecretCommandOutput,
+  GetSecretValueCommand,
+  GetSecretValueCommandOutput,
+} from '@aws-sdk/client-secrets-manager'
+import { AWSSecretsService } from './aws-secrets.service.js'
+import { EnvVars } from '../config/env_vars.js'
+import type { RedisClient } from '../../storage/redis/redis.client.js'
+
+interface AWSSecretsServiceInternals {
+  executeGetSecretValueCommandAws: (
+    command: GetSecretValueCommand,
+  ) => Promise<GetSecretValueCommandOutput>
+  executeCreateSecretCommandAws: (
+    command: CreateSecretCommand,
+  ) => Promise<CreateSecretCommandOutput>
+}
+
+interface AwsTestError extends Error {
+  code?: string
+  $metadata?: {
+    httpStatusCode?: number
+  }
+  $retryable?: {
+    throttling?: boolean
+  }
+}
+
+const makeAwsError = (
+  name: string,
+  options: {
+    code?: string
+    httpStatusCode?: number
+    retryable?: boolean
+  } = {},
+): AwsTestError => {
+  const error = new Error(name) as AwsTestError
+  error.name = name
+  error.code = options.code
+  error.$metadata =
+    options.httpStatusCode == null
+      ? undefined
+      : { httpStatusCode: options.httpStatusCode }
+  error.$retryable =
+    options.retryable === true ? { throttling: true } : undefined
+  return error
+}
+
+const createService = (): AWSSecretsService =>
+  new AWSSecretsService({ enabled: false } as unknown as RedisClient)
+
+const getInternals = (service: AWSSecretsService): AWSSecretsServiceInternals =>
+  service as unknown as AWSSecretsServiceInternals
+
+describe('AWSSecretsService', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      ENV: 'development',
+      AWS_REGION: 'us-east-1',
+      HCAPTCHA_SECRET_KEY: undefined,
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    jest.restoreAllMocks()
+  })
+
+  describe('get', () => {
+    it('returns undefined for missing AWS secrets', async () => {
+      const service = createService()
+      const getSecretSpy = jest
+        .spyOn(getInternals(service), 'executeGetSecretValueCommandAws')
+        .mockRejectedValueOnce(makeAwsError('ResourceNotFoundException'))
+
+      await expect(service.get('missing-secret')).resolves.toBeUndefined()
+      expect(getSecretSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('retries retryable AWS failures and throws after attempts are exhausted', async () => {
+      const service = createService()
+      const throttlingError = makeAwsError('ThrottlingException', {
+        httpStatusCode: 429,
+        retryable: true,
+      })
+      const getSecretSpy = jest
+        .spyOn(getInternals(service), 'executeGetSecretValueCommandAws')
+        .mockRejectedValue(throttlingError)
+
+      await expect(service.get('throttled-secret')).rejects.toThrow(
+        throttlingError,
+      )
+      expect(getSecretSpy).toHaveBeenCalledTimes(3)
+    })
+
+    it('returns the secret when a retry succeeds', async () => {
+      const service = createService()
+      const getSecretSpy = jest
+        .spyOn(getInternals(service), 'executeGetSecretValueCommandAws')
+        .mockRejectedValueOnce(
+          makeAwsError('InternalServiceError', { httpStatusCode: 500 }),
+        )
+        .mockResolvedValueOnce({ SecretString: 'retrieved-secret' })
+
+      await expect(service.get('eventual-secret')).resolves.toBe(
+        'retrieved-secret',
+      )
+      expect(getSecretSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('throws access denied errors without treating them as missing secrets', async () => {
+      const service = createService()
+      const accessDeniedError = makeAwsError('AccessDeniedException', {
+        httpStatusCode: 403,
+      })
+      const getSecretSpy = jest
+        .spyOn(getInternals(service), 'executeGetSecretValueCommandAws')
+        .mockRejectedValueOnce(accessDeniedError)
+
+      await expect(service.get('forbidden-secret')).rejects.toThrow(
+        accessDeniedError,
+      )
+      expect(getSecretSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws configuration errors without retrying', async () => {
+      const service = createService()
+      const configError = makeAwsError('UnrecognizedClientException', {
+        httpStatusCode: 400,
+      })
+      const getSecretSpy = jest
+        .spyOn(getInternals(service), 'executeGetSecretValueCommandAws')
+        .mockRejectedValueOnce(configError)
+
+      await expect(service.get('config-error-secret')).rejects.toThrow(
+        configError,
+      )
+      expect(getSecretSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('getSecretEnvVar', () => {
+    it('caches retrieved hCaptcha env secrets within the TTL', async () => {
+      const service = createService()
+      const getSecretSpy = jest
+        .spyOn(getInternals(service), 'executeGetSecretValueCommandAws')
+        .mockResolvedValue({ SecretString: '{"secret":"hcaptcha-secret"}' })
+
+      await expect(
+        service.getSecretEnvVar(EnvVars.HCAPTCHA_SECRET_KEY),
+      ).resolves.toBe('hcaptcha-secret')
+      await expect(
+        service.getSecretEnvVar(EnvVars.HCAPTCHA_SECRET_KEY),
+      ).resolves.toBe('hcaptcha-secret')
+
+      expect(getSecretSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('updates cached env secrets when matching AWS secrets are created', async () => {
+      const service = createService()
+      const getSecretSpy = jest
+        .spyOn(getInternals(service), 'executeGetSecretValueCommandAws')
+        .mockResolvedValueOnce({ SecretString: '{"secret":"old-secret"}' })
+      const createSecretSpy = jest
+        .spyOn(getInternals(service), 'executeCreateSecretCommandAws')
+        .mockResolvedValueOnce({})
+
+      await expect(
+        service.getSecretEnvVar(EnvVars.HCAPTCHA_SECRET_KEY),
+      ).resolves.toBe('old-secret')
+
+      await service.create('DEV_HCAPTCHA_SECRET_KEY', '{"secret":"new-secret"}')
+
+      await expect(
+        service.getSecretEnvVar(EnvVars.HCAPTCHA_SECRET_KEY),
+      ).resolves.toBe('new-secret')
+      expect(getSecretSpy).toHaveBeenCalledTimes(1)
+      expect(createSecretSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/app/src/nest/utils/aws/aws-secrets.service.spec.ts
+++ b/app/src/nest/utils/aws/aws-secrets.service.spec.ts
@@ -108,7 +108,10 @@ describe('AWSSecretsService', () => {
         .mockRejectedValueOnce(
           makeAwsError('InternalServiceError', { httpStatusCode: 500 }),
         )
-        .mockResolvedValueOnce({ SecretString: 'retrieved-secret' })
+        .mockResolvedValueOnce({
+          $metadata: {},
+          SecretString: 'retrieved-secret',
+        })
 
       await expect(service.get('eventual-secret')).resolves.toBe(
         'retrieved-secret',
@@ -152,7 +155,10 @@ describe('AWSSecretsService', () => {
       const service = createService()
       const getSecretSpy = jest
         .spyOn(getInternals(service), 'executeGetSecretValueCommandAws')
-        .mockResolvedValue({ SecretString: '{"secret":"hcaptcha-secret"}' })
+        .mockResolvedValue({
+          $metadata: {},
+          SecretString: '{"secret":"hcaptcha-secret"}',
+        })
 
       await expect(
         service.getSecretEnvVar(EnvVars.HCAPTCHA_SECRET_KEY),
@@ -168,10 +174,13 @@ describe('AWSSecretsService', () => {
       const service = createService()
       const getSecretSpy = jest
         .spyOn(getInternals(service), 'executeGetSecretValueCommandAws')
-        .mockResolvedValueOnce({ SecretString: '{"secret":"old-secret"}' })
+        .mockResolvedValueOnce({
+          $metadata: {},
+          SecretString: '{"secret":"old-secret"}',
+        })
       const createSecretSpy = jest
         .spyOn(getInternals(service), 'executeCreateSecretCommandAws')
-        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ $metadata: {} })
 
       await expect(
         service.getSecretEnvVar(EnvVars.HCAPTCHA_SECRET_KEY),

--- a/app/src/nest/utils/aws/aws-secrets.service.ts
+++ b/app/src/nest/utils/aws/aws-secrets.service.ts
@@ -20,25 +20,11 @@ import { isUint8Array } from 'util/types'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { Environment } from '../config/types.js'
 import { RedisClient } from '../../storage/redis/redis.client.js'
+import { AwsErrorShape, CachedSecretEnvVar } from './types.js'
 
 const GET_SECRET_MAX_ATTEMPTS = 3
 const GET_SECRET_RETRY_DELAY_MS = 100
 const ENV_SECRET_CACHE_TTL_MS = 5 * 60 * 1000
-
-interface CachedSecretEnvVar {
-  value: string
-  expiresAt: number
-}
-
-interface AwsErrorShape {
-  name?: string
-  code?: string
-  message?: string
-  $metadata?: {
-    httpStatusCode?: number
-  }
-  $retryable?: unknown
-}
 
 @Injectable()
 export class AWSSecretsService {
@@ -102,6 +88,7 @@ export class AWSSecretsService {
    *
    * @param secretName Secret to retrieve
    * @returns Retrieved encrypted secret value
+   * @throws Error if secret service is unavailable
    */
   public async get(
     secretName: string,

--- a/app/src/nest/utils/aws/aws-secrets.service.ts
+++ b/app/src/nest/utils/aws/aws-secrets.service.ts
@@ -17,8 +17,28 @@ import { EnvVars } from '../config/env_vars.js'
 import { createLogger } from '../../app/logger/logger.js'
 import { CompoundError } from '../errors.js'
 import { isUint8Array } from 'util/types'
+import { setTimeout as sleep } from 'node:timers/promises'
 import { Environment } from '../config/types.js'
 import { RedisClient } from '../../storage/redis/redis.client.js'
+
+const GET_SECRET_MAX_ATTEMPTS = 3
+const GET_SECRET_RETRY_DELAY_MS = 100
+const ENV_SECRET_CACHE_TTL_MS = 5 * 60 * 1000
+
+interface CachedSecretEnvVar {
+  value: string
+  expiresAt: number
+}
+
+interface AwsErrorShape {
+  name?: string
+  code?: string
+  message?: string
+  $metadata?: {
+    httpStatusCode?: number
+  }
+  $retryable?: unknown
+}
 
 @Injectable()
 export class AWSSecretsService {
@@ -36,6 +56,8 @@ export class AWSSecretsService {
   private readonly client: SecretsManagerClient | undefined
 
   private readonly logger = createLogger(`Utils:${AWSSecretsService.name}`)
+
+  private readonly secretEnvVarCache = new Map<string, CachedSecretEnvVar>()
 
   /**
    * @param redisClient Redis client for local instances
@@ -83,24 +105,52 @@ export class AWSSecretsService {
    */
   public async get(
     secretName: string,
-  ): Promise<string | Uint8Array | undefined | null> {
-    try {
-      // if local fetch the secret from Redis and return
-      if (this.local) {
-        return await this.redisClient.get(secretName)
-      }
-
-      // generate the AWS secrets manager command and fetch
-      const commandInput: GetSecretValueCommandInput = {
-        SecretId: secretName,
-      }
-      const command = new GetSecretValueCommand(commandInput)
-      const response = await this.executeGetSecretValueCommandAws(command)
-      return response.SecretString ?? response.SecretBinary
-    } catch (e) {
-      this.logger.error('Error retrieving secret from AWS', e)
-      return undefined
+  ): Promise<string | Uint8Array | undefined> {
+    // if local fetch the secret from Redis and return
+    if (this.local) {
+      return (await this.redisClient.get(secretName)) ?? undefined
     }
+
+    // generate the AWS secrets manager command and fetch
+    const commandInput: GetSecretValueCommandInput = {
+      SecretId: secretName,
+    }
+    const command = new GetSecretValueCommand(commandInput)
+    let lastError: Error | undefined
+    for (let attempt = 1; attempt <= GET_SECRET_MAX_ATTEMPTS; attempt++) {
+      try {
+        const response = await this.executeGetSecretValueCommandAws(command)
+        const secret = response.SecretString ?? response.SecretBinary
+        if (secret == null) {
+          throw new Error(
+            `Secret ${secretName} was found but did not include a secret value`,
+          )
+        }
+        return secret
+      } catch (e) {
+        if (AWSSecretsService.isSecretNotFoundError(e)) {
+          return undefined
+        }
+
+        lastError = AWSSecretsService.normalizeError(e)
+        if (
+          attempt < GET_SECRET_MAX_ATTEMPTS &&
+          AWSSecretsService.isRetryableGetSecretError(e)
+        ) {
+          this.logger.warn(
+            `Retrying AWS secret retrieval after attempt ${attempt} failed`,
+            e,
+          )
+          await sleep(GET_SECRET_RETRY_DELAY_MS)
+          continue
+        }
+
+        this.logger.error('Error retrieving secret from AWS', e)
+        throw lastError
+      }
+    }
+
+    throw lastError ?? new Error('Error retrieving secret from AWS')
   }
 
   public async getSecretEnvVar(
@@ -114,6 +164,11 @@ export class AWSSecretsService {
     const envScopedSecretName = useEnvScopedName
       ? `${ConfigService.getString(EnvVars.ENV)?.toLowerCase() === 'development' ? 'DEV' : 'PROD'}_${secretName}`
       : secretName
+    const cachedSecret = this.getCachedSecretEnvVar(envScopedSecretName)
+    if (cachedSecret != null) {
+      return cachedSecret
+    }
+
     const secret = await this.get(envScopedSecretName)
     let secretString =
       secret == null ? undefined : AWSSecretsService.parseSecretString(secret)
@@ -127,6 +182,7 @@ export class AWSSecretsService {
       }
       secretString = localSecret
     }
+    this.setCachedSecretEnvVar(envScopedSecretName, secretString)
     return secretString
   }
 
@@ -144,6 +200,7 @@ export class AWSSecretsService {
       // if local add the secret to Redis and return
       if (this.local) {
         await this.redisClient.set(secretName, secret)
+        this.updateCachedSecretEnvVar(secretName, secret)
         return
       }
 
@@ -161,9 +218,13 @@ export class AWSSecretsService {
 
       const command = new CreateSecretCommand(commandInput)
       await this.executeCreateSecretCommandAws(command)
+      this.updateCachedSecretEnvVar(secretName, secret)
     } catch (e) {
       this.logger.error('Error putting secret:', e)
-      throw new CompoundError('Error putting secret into AWS', e as Error)
+      throw new CompoundError(
+        'Error putting secret into AWS',
+        AWSSecretsService.normalizeError(e),
+      )
     }
   }
 
@@ -201,8 +262,105 @@ export class AWSSecretsService {
       typeof value === 'object' &&
       value !== null &&
       'secret' in value &&
-      typeof (value as { secret?: unknown }).secret === 'string'
+      typeof value.secret === 'string'
     )
+  }
+
+  private static isSecretNotFoundError(error: unknown): boolean {
+    const awsError = AWSSecretsService.toAwsErrorShape(error)
+    return (
+      awsError.name === 'ResourceNotFoundException' ||
+      awsError.code === 'ResourceNotFoundException' ||
+      awsError.$metadata?.httpStatusCode === 404
+    )
+  }
+
+  private static isRetryableGetSecretError(error: unknown): boolean {
+    const awsError = AWSSecretsService.toAwsErrorShape(error)
+    const errorName = awsError.name ?? awsError.code
+    const statusCode = awsError.$metadata?.httpStatusCode
+
+    if (
+      statusCode != null &&
+      (statusCode === 408 || statusCode === 429 || statusCode >= 500)
+    ) {
+      return true
+    }
+    if (awsError.$retryable != null) {
+      return true
+    }
+    if (
+      errorName != null &&
+      [
+        'InternalServiceError',
+        'InternalServiceErrorException',
+        'ServiceUnavailableException',
+        'ThrottlingException',
+        'TooManyRequestsException',
+        'TimeoutError',
+        'TimeoutException',
+        'RequestTimeout',
+        'NetworkingError',
+        'NetworkError',
+      ].includes(errorName)
+    ) {
+      return true
+    }
+
+    const errorMessage = awsError.message?.toLowerCase()
+    return (
+      errorMessage?.includes('timeout') === true ||
+      errorMessage?.includes('network') === true ||
+      errorMessage?.includes('socket hang up') === true ||
+      errorMessage?.includes('econnreset') === true
+    )
+  }
+
+  private static toAwsErrorShape(error: unknown): AwsErrorShape {
+    if (typeof error !== 'object' || error === null) {
+      return {}
+    }
+    return error as AwsErrorShape
+  }
+
+  private static normalizeError(error: unknown): Error {
+    if (error instanceof Error) {
+      return error
+    }
+    return new Error(
+      typeof error === 'string' ? error : 'Unknown AWS secrets service error',
+    )
+  }
+
+  private getCachedSecretEnvVar(secretName: string): string | undefined {
+    const cachedSecret = this.secretEnvVarCache.get(secretName)
+    if (cachedSecret == null) {
+      return undefined
+    }
+    if (cachedSecret.expiresAt <= Date.now()) {
+      this.secretEnvVarCache.delete(secretName)
+      return undefined
+    }
+    return cachedSecret.value
+  }
+
+  private setCachedSecretEnvVar(secretName: string, secret: string): void {
+    this.secretEnvVarCache.set(secretName, {
+      value: secret,
+      expiresAt: Date.now() + ENV_SECRET_CACHE_TTL_MS,
+    })
+  }
+
+  private updateCachedSecretEnvVar(
+    secretName: string,
+    secret: string | Uint8Array,
+  ): void {
+    const secretString = AWSSecretsService.parseSecretString(secret)
+    if (secretString == null) {
+      this.secretEnvVarCache.delete(secretName)
+      return
+    }
+    this.setCachedSecretEnvVar(secretName, secretString)
   }
 
   private getAwsClient(): SecretsManagerClient {

--- a/app/src/nest/utils/aws/types.ts
+++ b/app/src/nest/utils/aws/types.ts
@@ -2,3 +2,18 @@ export interface RDSCredentials {
   username: string
   password: string
 }
+
+export interface CachedSecretEnvVar {
+  value: string
+  expiresAt: number
+}
+
+export interface AwsErrorShape {
+  name?: string
+  code?: string
+  message?: string
+  $metadata?: {
+    httpStatusCode?: number
+  }
+  $retryable?: unknown
+}


### PR DESCRIPTION
Fail loudly on secrets retrieval errors

Fixes #3290

Previously AWSSecretsService.get() swallowed all errors and returned undefined, making a transient Secrets Manager outage indistinguishable from a genuinely missing secret. Callers would then treat the gap as "no secret" and silently generate fresh keys — rotating signing keys, invalidating issued tokens, and masking misconfiguration.

Changes

- AWSSecretsService.get now distinguishes failure modes:
  - Missing secret (ResourceNotFoundException / 404) → undefined (unchanged contract for "not found").
  - Transient errors (timeouts, throttling, 5xx, network) → retried up to 3× (100ms backoff), then throw.
  - Non-retryable errors → throw immediately.
- In-memory env-var cache (5min TTL) for resolved secrets, kept warm on put.
- NseJwtOptionsService: removed the random fallback secret; a missing/unavailable NSE_JWT_SECRET now throws instead of silently rotating the JWT signing key.
- PushService: iOS/Android FCM key retrieval failures are caught and degrade gracefully (mark platform unavailable) rather than crashing init.
- UcanService / ServerKeyManagerService: no longer regenerate keys on transient retrieval failure — only when the secret genuinely doesn't exist.
- Removed unused DEFAULT_POSTGRES_* constants.

Tests

Added coverage for retry/throw behavior, the not-found path, and the "don't regenerate keys on transient failure" guarantee across AWSSecretsService, UcanService, and ServerKeyManagerService.